### PR TITLE
Implement role-based access control

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -7,10 +7,11 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use Spatie\Permission\Traits\HasRoles;
 
 class User extends Authenticatable
 {
-    use HasApiTokens, HasFactory, Notifiable;
+    use HasApiTokens, HasFactory, Notifiable, HasRoles;
 
     /**
      * The attributes that are mass assignable.

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,11 +12,6 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // \App\Models\User::factory(10)->create();
-
-        // \App\Models\User::factory()->create([
-        //     'name' => 'Test User',
-        //     'email' => 'test@example.com',
-        // ]);
+        $this->call(RoleSeeder::class);
     }
 }

--- a/database/seeders/RoleSeeder.php
+++ b/database/seeders/RoleSeeder.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+class RoleSeeder extends Seeder
+{
+    public function run(): void
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        // create permissions
+        Permission::firstOrCreate(['name' => 'manage users']);
+        Permission::firstOrCreate(['name' => 'manage settings']);
+        Permission::firstOrCreate(['name' => 'clinical functions']);
+        Permission::firstOrCreate(['name' => 'manage appointments']);
+        Permission::firstOrCreate(['name' => 'support patients']);
+
+        // create roles and assign permissions
+        $admin = Role::firstOrCreate(['name' => 'adm']);
+        $admin->givePermissionTo(['manage users', 'manage settings']);
+
+        $medico = Role::firstOrCreate(['name' => 'medico']);
+        $medico->givePermissionTo(['clinical functions', 'manage appointments']);
+
+        $enfermeiro = Role::firstOrCreate(['name' => 'enfermeiro']);
+        $enfermeiro->givePermissionTo(['support patients']);
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -20,12 +20,16 @@ Route::redirect('/', '/login');
 
 Route::get('/dashboard', function () {
     return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified'])->name('dashboard');
+})->middleware(['auth', 'verified', 'role:adm|medico|enfermeiro'])->name('dashboard');
 
-Route::middleware('auth')->group(function () {
+Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
 });
+
+Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
+Route::middleware(['auth', 'role:medico'])->get('/medico', fn () => 'medico area');
+Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => 'enfermeiro area');
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/ExampleTest.php
+++ b/tests/Feature/ExampleTest.php
@@ -10,10 +10,10 @@ class ExampleTest extends TestCase
     /**
      * A basic test example.
      */
-    public function test_the_application_returns_a_successful_response(): void
+    public function test_the_application_returns_a_redirect_response(): void
     {
         $response = $this->get('/');
 
-        $response->assertStatus(200);
+        $response->assertStatus(302);
     }
 }

--- a/tests/Feature/RoleAccessTest.php
+++ b/tests/Feature/RoleAccessTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class RoleAccessTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+    }
+
+    public function test_admin_access()
+    {
+        $user = User::factory()->create();
+        $user->assignRole('adm');
+
+        $this->actingAs($user)->get('/admin')->assertOk();
+        $this->actingAs($user)->get('/medico')->assertForbidden();
+        $this->actingAs($user)->get('/enfermeiro')->assertForbidden();
+    }
+
+    public function test_medico_access()
+    {
+        $user = User::factory()->create();
+        $user->assignRole('medico');
+
+        $this->actingAs($user)->get('/medico')->assertOk();
+        $this->actingAs($user)->get('/admin')->assertForbidden();
+        $this->actingAs($user)->get('/enfermeiro')->assertForbidden();
+    }
+
+    public function test_enfermeiro_access()
+    {
+        $user = User::factory()->create();
+        $user->assignRole('enfermeiro');
+
+        $this->actingAs($user)->get('/enfermeiro')->assertOk();
+        $this->actingAs($user)->get('/admin')->assertForbidden();
+        $this->actingAs($user)->get('/medico')->assertForbidden();
+    }
+}


### PR DESCRIPTION
## Summary
- add Spatie role support to users
- seed roles and permissions
- guard routes by role and test access

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --ignore-platform-reqs` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68bedd32fae8832aaf39899b14c5eea4