### PR TITLE
feat: add user seeder with roles

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -12,6 +12,9 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call(RoleSeeder::class);
+        $this->call([
+            RoleSeeder::class,
+            UserSeeder::class,
+        ]);
     }
 }

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\User;
+use Illuminate\Database\Seeder;
+
+class UserSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $admin = User::firstOrCreate(
+            ['email' => 'admin@example.com'],
+            [
+                'name' => 'Administrador',
+                'username' => 'admin',
+                'password' => 'password',
+            ]
+        );
+        $admin->assignRole('adm');
+
+        $medico = User::firstOrCreate(
+            ['email' => 'medico@example.com'],
+            [
+                'name' => 'Medico',
+                'username' => 'medico',
+                'password' => 'password',
+            ]
+        );
+        $medico->assignRole('medico');
+
+        $enfermeiro = User::firstOrCreate(
+            ['email' => 'enfermeiro@example.com'],
+            [
+                'name' => 'Enfermeiro',
+                'username' => 'enfermeiro',
+                'password' => 'password',
+            ]
+        );
+        $enfermeiro->assignRole('enfermeiro');
+    }
+}


### PR DESCRIPTION
## Summary
- add user seeder creating default admin, medico, and enfermeiro accounts
- register user seeder in main database seeder

## Testing
- `php artisan db:seed` *(fails: require(/workspace/calendario/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68beea5b9178832abc283c9f5f9732ae