### PR TITLE
Add Spatie permission middleware aliases

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -66,5 +66,8 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'role' => \Spatie\Permission\Middlewares\RoleMiddleware::class,
+        'permission' => \Spatie\Permission\Middlewares\PermissionMiddleware::class,
+        'role_or_permission' => \Spatie\Permission\Middlewares\RoleOrPermissionMiddleware::class,
     ];
 }


### PR DESCRIPTION
## Summary
- add Spatie\Permission middleware aliases in Http kernel for role and permission checks

## Testing
- `php artisan optimize:clear` *(fails: requires vendor/autoload.php; composer install unsupported for PHP 8.4)*

------
https://chatgpt.com/codex/tasks/task_e_68bf05db6968832a825b9287f793315a