### PR TITLE
Add surgery room conflict validation

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Surgery;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+
+class SurgeryController extends Controller
+{
+    /**
+     * Store a newly created surgery in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $data = $request->validate([
+            'doctor_id' => ['required', 'exists:users,id'],
+            'room_number' => ['required', 'integer'],
+            'start_time' => ['required', 'date'],
+            'end_time' => ['required', 'date', 'after:start_time'],
+        ]);
+
+        if (Surgery::roomConflicts($data['room_number'], $data['start_time'], $data['end_time'])->exists()) {
+            return back()->withErrors([
+                'room_number' => 'Room already booked for the selected time.',
+            ]);
+        }
+
+        Surgery::create($data);
+
+        return back();
+    }
+}
+

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Surgery extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'doctor_id',
+        'room_number',
+        'start_time',
+        'end_time',
+    ];
+
+    /**
+     * Scope a query to only include surgeries that conflict with the given room and time.
+     */
+    public function scopeRoomConflicts(Builder $query, int $roomNumber, $startTime, $endTime): Builder
+    {
+        return $query->where('room_number', $roomNumber)
+            ->where(function (Builder $query) use ($startTime, $endTime) {
+                $query->where('start_time', '<', $endTime)
+                    ->where('end_time', '>', $startTime);
+            });
+    }
+}
+

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Surgery;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<Surgery>
+ */
+class SurgeryFactory extends Factory
+{
+    protected $model = Surgery::class;
+
+    public function definition(): array
+    {
+        $start = Carbon::instance($this->faker->dateTimeBetween('now', '+1 week'));
+        $end = (clone $start)->addHour();
+
+        return [
+            'doctor_id' => User::factory(),
+            'room_number' => $this->faker->numberBetween(1, 10),
+            'start_time' => $start,
+            'end_time' => $end,
+        ];
+    }
+}
+

--- a/database/migrations/2025_09_08_150000_create_surgeries_table.php
+++ b/database/migrations/2025_09_08_150000_create_surgeries_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('surgeries', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('doctor_id')->constrained('users')->cascadeOnDelete();
+            $table->integer('room_number');
+            $table->timestamp('start_time');
+            $table->timestamp('end_time');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('surgeries');
+    }
+};
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SurgeryController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -31,5 +32,6 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
 Route::middleware(['auth', 'role:medico'])->get('/medico', fn () => 'medico area');
 Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => 'enfermeiro area');
+Route::middleware(['auth', 'role:medico'])->post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Surgery;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SurgeryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+    }
+
+    public function test_cannot_schedule_surgery_in_occupied_room(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $existing = Surgery::factory()->create([
+            'room_number' => 1,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+        ]);
+
+        $response = $this->actingAs($doctor)->post('/surgeries', [
+            'doctor_id' => $doctor->id,
+            'room_number' => 1,
+            'start_time' => $existing->start_time->copy()->addMinutes(30),
+            'end_time' => $existing->end_time->copy()->addMinutes(30),
+        ]);
+
+        $response->assertSessionHasErrors('room_number');
+    }
+}
+


### PR DESCRIPTION
## Summary
- add Surgery model with room/time conflict scope
- validate room availability before storing new surgery
- cover scheduling conflict with feature test

## Testing
- `php -l app/Models/Surgery.php app/Http/Controllers/SurgeryController.php tests/Feature/SurgeryTest.php database/factories/SurgeryFactory.php database/migrations/2025_09_08_150000_create_surgeries_table.php`
- `composer install --ignore-platform-reqs` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0ea0b85c832a91f6d5fbdbb86173