### PR TITLE
feat: track surgery audit

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Surgery;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+
+class SurgeryController extends Controller
+{
+    public function index()
+    {
+        $surgeries = Surgery::with(['creator', 'confirmer'])->get()->map(function ($surgery) {
+            return [
+                'id' => $surgery->id,
+                'title' => $surgery->title,
+                'scheduled_at' => optional($surgery->scheduled_at)->toDateTimeString(),
+                'creator' => $surgery->creator ? $surgery->creator->only(['id', 'name']) : null,
+                'confirmer' => $surgery->confirmer ? $surgery->confirmer->only(['id', 'name']) : null,
+            ];
+        });
+
+        return Inertia::render('Dashboard', [
+            'surgeries' => $surgeries,
+        ]);
+    }
+
+    public function store(Request $request)
+    {
+        $data = $request->validate([
+            'title' => 'required|string',
+            'scheduled_at' => 'required|date',
+        ]);
+
+        $data['created_by'] = $request->user()->id;
+
+        Surgery::create($data);
+
+        return redirect()->route('dashboard');
+    }
+
+    public function confirm(Request $request, Surgery $surgery)
+    {
+        $surgery->update([
+            'confirmed_by' => $request->user()->id,
+        ]);
+
+        return redirect()->route('dashboard');
+    }
+}

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Surgery extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'title',
+        'scheduled_at',
+        'created_by',
+        'confirmed_by',
+    ];
+
+    protected $casts = [
+        'scheduled_at' => 'datetime',
+    ];
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function confirmer()
+    {
+        return $this->belongsTo(User::class, 'confirmed_by');
+    }
+}

--- a/database/migrations/2025_09_08_150000_create_surgeries_table.php
+++ b/database/migrations/2025_09_08_150000_create_surgeries_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('surgeries', function (Blueprint $table) {
+            $table->id();
+            $table->string('title');
+            $table->timestamp('scheduled_at')->nullable();
+            $table->foreignId('created_by')->constrained('users');
+            $table->foreignId('confirmed_by')->nullable()->constrained('users');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('surgeries');
+    }
+};

--- a/resources/js/Pages/Dashboard.vue
+++ b/resources/js/Pages/Dashboard.vue
@@ -1,6 +1,13 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
 import { Head } from '@inertiajs/vue3';
+
+const props = defineProps({
+    surgeries: {
+        type: Array,
+        default: () => [],
+    },
+});
 </script>
 
 <template>
@@ -14,7 +21,15 @@ import { Head } from '@inertiajs/vue3';
         <div class="py-12">
             <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
                 <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg">
-                    <div class="p-6 text-gray-900">You're logged in!</div>
+                    <div class="p-6 text-gray-900">
+                        <ul>
+                            <li v-for="surgery in surgeries" :key="surgery.id">
+                                <span :title="`Criado por: ${surgery.creator?.name ?? 'N/A'}\nConfirmado por: ${surgery.confirmer?.name ?? 'Pendente'}`">
+                                    {{ surgery.title }}
+                                </span>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
         </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\SurgeryController;
 use Inertia\Inertia;
 
 /*
@@ -18,9 +19,7 @@ use Inertia\Inertia;
 
 Route::redirect('/', '/login');
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
-})->middleware(['auth', 'verified', 'role:adm|medico|enfermeiro'])->name('dashboard');
+Route::get('/dashboard', [SurgeryController::class, 'index'])->middleware(['auth', 'verified', 'role:adm|medico|enfermeiro'])->name('dashboard');
 
 Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
@@ -31,5 +30,8 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
 Route::middleware(['auth', 'role:medico'])->get('/medico', fn () => 'medico area');
 Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => 'enfermeiro area');
+
+Route::middleware(["auth", "role:medico"])->post("/surgeries", [SurgeryController::class, "store"]);
+Route::middleware(["auth", "role:enfermeiro"])->post("/surgeries/{surgery}/confirm", [SurgeryController::class, "confirm"]);
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/SurgeryAuditTest.php
+++ b/tests/Feature/SurgeryAuditTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Surgery;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SurgeryAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+    }
+
+    public function test_audit_fields_are_recorded_and_displayed()
+    {
+        $doctor = User::factory()->create(['name' => 'Dr. Who']);
+        $doctor->assignRole('medico');
+
+        $nurse = User::factory()->create(['name' => 'Nurse Joy']);
+        $nurse->assignRole('enfermeiro');
+
+        $this->actingAs($doctor)->post('/surgeries', [
+            'title' => 'Appendectomy',
+            'scheduled_at' => now()->toDateTimeString(),
+        ]);
+
+        $surgery = Surgery::first();
+        $this->assertEquals($doctor->id, $surgery->created_by);
+        $this->assertNull($surgery->confirmed_by);
+
+        $this->actingAs($nurse)->post("/surgeries/{$surgery->id}/confirm");
+
+        $surgery->refresh();
+        $this->assertEquals($nurse->id, $surgery->confirmed_by);
+
+        $this->actingAs($doctor)->get('/dashboard')
+            ->assertSee('Dr. Who')
+            ->assertSee('Nurse Joy');
+    }
+}


### PR DESCRIPTION
## Summary
- add surgeries model and table with audit fields
- record doctor and nurse IDs when surgeries are created and confirmed
- display audit data in dashboard tooltip and cover in feature test

## Testing
- `composer install --ignore-platform-reqs` *(fails: requires GitHub token)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0ea37df4832ab195c346451890d6