### PR TITLE
feat: add calendar notifications and tests

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class SurgeryController extends Controller
+{
+    /**
+     * Handle a newly created surgery request.
+     */
+    public function store(Request $request)
+    {
+        return redirect()->route('calendar')->with('message', 'Surgery created successfully.');
+    }
+
+    /**
+     * Handle confirming a surgery.
+     */
+    public function confirm(Request $request)
+    {
+        return redirect()->route('calendar')->with('message', 'Surgery confirmed.');
+    }
+}

--- a/resources/js/Pages/Calendar.vue
+++ b/resources/js/Pages/Calendar.vue
@@ -1,0 +1,23 @@
+<template>
+    <div>
+        <div v-if="$page.props.flash.message" class="mb-4 text-green-600">
+            {{ $page.props.flash.message }}
+        </div>
+        <PrimaryButton @click="createSurgery">Create Surgery</PrimaryButton>
+        <SecondaryButton class="ml-2" @click="confirmSurgery">Confirm Surgery</SecondaryButton>
+    </div>
+</template>
+
+<script setup>
+import { router } from '@inertiajs/vue3';
+import PrimaryButton from '@/Components/PrimaryButton.vue';
+import SecondaryButton from '@/Components/SecondaryButton.vue';
+
+function createSurgery() {
+    router.post(route('surgery.store'));
+}
+
+function confirmSurgery() {
+    router.post(route('surgery.confirm'));
+}
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\SurgeryController;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -26,6 +27,10 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
     Route::get('/profile', [ProfileController::class, 'edit'])->name('profile.edit');
     Route::patch('/profile', [ProfileController::class, 'update'])->name('profile.update');
     Route::delete('/profile', [ProfileController::class, 'destroy'])->name('profile.destroy');
+
+    Route::get('/calendar', fn () => Inertia::render('Calendar'))->name('calendar');
+    Route::post('/calendar/create-surgery', [SurgeryController::class, 'store'])->name('surgery.store');
+    Route::post('/calendar/confirm-surgery', [SurgeryController::class, 'confirm'])->name('surgery.confirm');
 });
 
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');

--- a/tests/Feature/SurgeryMessageTest.php
+++ b/tests/Feature/SurgeryMessageTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SurgeryMessageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_flash_message_after_creating_surgery(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('surgery.store'));
+
+        $response->assertRedirect(route('calendar'));
+        $response->assertSessionHas('message', 'Surgery created successfully.');
+    }
+
+    public function test_flash_message_after_confirming_surgery(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->post(route('surgery.confirm'));
+
+        $response->assertRedirect(route('calendar'));
+        $response->assertSessionHas('message', 'Surgery confirmed.');
+    }
+}


### PR DESCRIPTION
## Summary
- add backend routes and controller to send flash messages when creating or confirming surgeries
- show flash messages in new Calendar page via Inertia/Vue
- cover flash messages with feature tests

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*
- `composer install --ignore-platform-reqs` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68bf0ea614e4832aabba59dbf6bbca1b