### PR TITLE
Notify doctor of upcoming surgery

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers;
 
 use App\Models\Surgery;
+use App\Models\User;
+use App\Notifications\UpcomingSurgery;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 
@@ -26,7 +28,11 @@ class SurgeryController extends Controller
             ]);
         }
 
-        Surgery::create($data);
+        $surgery = Surgery::create($data);
+
+        if ($doctor = User::find($surgery->doctor_id)) {
+            $doctor->notify(new UpcomingSurgery($surgery->start_time));
+        }
 
         return back();
     }

--- a/app/Notifications/UpcomingSurgery.php
+++ b/app/Notifications/UpcomingSurgery.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class UpcomingSurgery extends Notification
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(public $scheduledTime)
+    {
+        //
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->line('You have an upcoming surgery scheduled at ' . $this->scheduledTime)
+            ->line('Thank you for using our application!');
+    }
+}

--- a/tests/Feature/SurgeryNotificationTest.php
+++ b/tests/Feature/SurgeryNotificationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Notifications\UpcomingSurgery;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class SurgeryNotificationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+    }
+
+    public function test_notification_sent_when_surgery_stored(): void
+    {
+        Notification::fake();
+
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $this->actingAs($doctor)->post('/surgeries', [
+            'doctor_id' => $doctor->id,
+            'room_number' => 1,
+            'start_time' => now()->addHour(),
+            'end_time' => now()->addHours(2),
+        ]);
+
+        Notification::assertSentTo($doctor, UpcomingSurgery::class);
+    }
+}


### PR DESCRIPTION
## Summary
- add UpcomingSurgery notification
- send notification to doctor when surgery scheduled
- test surgery scheduling triggers notification

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/calendario/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68bf1274f4a0832a8dec6997c2e91232