### PR TITLE
Add surgery audit logging

### DIFF
--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class Surgery extends Model
 {
@@ -27,6 +28,41 @@ class Surgery extends Model
                 $query->where('start_time', '<', $endTime)
                     ->where('end_time', '>', $startTime);
             });
+    }
+
+    public function audits(): HasMany
+    {
+        return $this->hasMany(SurgeryAudit::class);
+    }
+
+    protected static function booted(): void
+    {
+        static::created(function (Surgery $surgery) {
+            $surgery->audits()->create([
+                'doctor_id' => $surgery->doctor_id,
+                'room_number' => $surgery->room_number,
+                'start_time' => $surgery->start_time,
+                'end_time' => $surgery->end_time,
+            ]);
+        });
+
+        static::updated(function (Surgery $surgery) {
+            $surgery->audits()->create([
+                'doctor_id' => $surgery->doctor_id,
+                'room_number' => $surgery->room_number,
+                'start_time' => $surgery->start_time,
+                'end_time' => $surgery->end_time,
+            ]);
+        });
+
+        static::deleted(function (Surgery $surgery) {
+            $surgery->audits()->create([
+                'doctor_id' => $surgery->doctor_id,
+                'room_number' => $surgery->room_number,
+                'start_time' => $surgery->start_time,
+                'end_time' => $surgery->end_time,
+            ]);
+        });
     }
 }
 

--- a/app/Models/SurgeryAudit.php
+++ b/app/Models/SurgeryAudit.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SurgeryAudit extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'surgery_id',
+        'doctor_id',
+        'room_number',
+        'start_time',
+        'end_time',
+    ];
+
+    public function surgery(): BelongsTo
+    {
+        return $this->belongsTo(Surgery::class);
+    }
+}

--- a/database/migrations/2025_09_08_160000_create_surgery_audits_table.php
+++ b/database/migrations/2025_09_08_160000_create_surgery_audits_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('surgery_audits', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('surgery_id');
+            $table->unsignedBigInteger('doctor_id');
+            $table->integer('room_number');
+            $table->timestamp('start_time');
+            $table->timestamp('end_time');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('surgery_audits');
+    }
+};

--- a/tests/Feature/SurgeryAuditTest.php
+++ b/tests/Feature/SurgeryAuditTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Surgery;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SurgeryAuditTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_audit_entry_created_when_surgery_scheduled(): void
+    {
+        $surgery = Surgery::factory()->create();
+
+        $this->assertDatabaseHas('surgery_audits', [
+            'surgery_id' => $surgery->id,
+            'doctor_id' => $surgery->doctor_id,
+            'room_number' => $surgery->room_number,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `surgery_audits` table for recording surgery changes
- create `SurgeryAudit` model and hook `Surgery` events to write audits
- add feature test verifying audit record on surgery creation

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/calendario/vendor/autoload.php')*
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68bf12772b18832a8b4dd1d740bcc53f