### PR TITLE
Restrict surgery creation to authenticated doctor

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -20,6 +20,12 @@ class SurgeryController extends Controller
             'end_time' => ['required', 'date', 'after:start_time'],
         ]);
 
+        if ($request->user()->id !== $data['doctor_id']) {
+            return back()->withErrors([
+                'doctor_id' => 'Doctors can only schedule surgeries for themselves.',
+            ]);
+        }
+
         if (Surgery::roomConflicts($data['room_number'], $data['start_time'], $data['end_time'])->exists()) {
             return back()->withErrors([
                 'room_number' => 'Room already booked for the selected time.',

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -38,5 +38,22 @@ class SurgeryTest extends TestCase
 
         $response->assertSessionHasErrors('room_number');
     }
+
+    public function test_doctor_cannot_schedule_surgery_for_another_user(): void
+    {
+        $doctor = User::factory()->create();
+        $otherDoctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $otherDoctor->assignRole('medico');
+
+        $response = $this->actingAs($doctor)->post('/surgeries', [
+            'doctor_id' => $otherDoctor->id,
+            'room_number' => 1,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+        ]);
+
+        $response->assertSessionHasErrors('doctor_id');
+    }
 }
 


### PR DESCRIPTION
## Summary
- ensure SurgeryController only allows doctors to create surgeries for themselves
- add feature test preventing doctors from scheduling surgeries for others

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing because composer install required GitHub auth)*

------
https://chatgpt.com/codex/tasks/task_e_68bf12774608832aac2c8551a0627d9e