### PR TITLE
test: add surgery scheduling authorization tests

### DIFF
--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -38,5 +38,67 @@ class SurgeryTest extends TestCase
 
         $response->assertSessionHasErrors('room_number');
     }
+
+    public function test_doctor_can_schedule_non_conflicting_surgery(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        Surgery::factory()->create([
+            'room_number' => 1,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+        ]);
+
+        $start = now()->addDays(2);
+        $end = $start->copy()->addHour();
+
+        $response = $this->actingAs($doctor)->post('/surgeries', [
+            'doctor_id' => $doctor->id,
+            'room_number' => 1,
+            'start_time' => $start,
+            'end_time' => $end,
+        ]);
+
+        $response->assertStatus(302);
+        $this->assertDatabaseHas('surgeries', [
+            'doctor_id' => $doctor->id,
+            'room_number' => 1,
+            'start_time' => $start->toDateTimeString(),
+            'end_time' => $end->toDateTimeString(),
+        ]);
+    }
+
+    public function test_nurse_cannot_schedule_surgery(): void
+    {
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        $response = $this->actingAs($nurse)->post('/surgeries', [
+            'doctor_id' => $nurse->id,
+            'room_number' => 1,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('surgeries', 0);
+    }
+
+    public function test_admin_cannot_schedule_surgery(): void
+    {
+        $admin = User::factory()->create();
+        $admin->assignRole('adm');
+
+        $response = $this->actingAs($admin)->post('/surgeries', [
+            'doctor_id' => $admin->id,
+            'room_number' => 1,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+        ]);
+
+        $response->assertForbidden();
+        $this->assertDatabaseCount('surgeries', 0);
+    }
 }
 


### PR DESCRIPTION
## Summary
- add happy path test for doctors scheduling a non-conflicting surgery
- cover unauthorized roles (nurse and admin) that are blocked from scheduling surgeries

## Testing
- `composer install`
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68bf12784e9c832abbd5f36bdb70f31b