### PR TITLE
Add authorization tests for surgery scheduling

### DIFF
--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -18,6 +18,63 @@ class SurgeryTest extends TestCase
         $this->seed(RoleSeeder::class);
     }
 
+    public function test_guest_is_redirected_when_posting_surgery(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $response = $this->post('/surgeries', [
+            'doctor_id' => $doctor->id,
+            'room_number' => 1,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+        ]);
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_non_medico_users_cannot_schedule_surgery(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        foreach ([null, 'adm', 'enfermeiro'] as $role) {
+            $user = User::factory()->create();
+            if ($role) {
+                $user->assignRole($role);
+            }
+
+            $response = $this->actingAs($user)->post('/surgeries', [
+                'doctor_id' => $doctor->id,
+                'room_number' => 1,
+                'start_time' => now()->addDay(),
+                'end_time' => now()->addDay()->addHour(),
+            ]);
+
+            $response->assertForbidden();
+        }
+    }
+
+    public function test_medico_can_schedule_surgery(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $response = $this->actingAs($doctor)->post('/surgeries', [
+            'doctor_id' => $doctor->id,
+            'room_number' => 1,
+            'start_time' => now()->addDay(),
+            'end_time' => now()->addDay()->addHour(),
+        ]);
+
+        $response->assertRedirect('/');
+
+        $this->assertDatabaseHas('surgeries', [
+            'doctor_id' => $doctor->id,
+            'room_number' => 1,
+        ]);
+    }
+
     public function test_cannot_schedule_surgery_in_occupied_room(): void
     {
         $doctor = User::factory()->create();


### PR DESCRIPTION
## Summary
- add tests covering surgery access control for guests and non-medical roles
- ensure doctors with medico role can schedule surgeries and others are denied

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install --ignore-platform-reqs` *(fails: curl error 56/403 reaching GitHub)*

------
https://chatgpt.com/codex/tasks/task_e_68bf15fe0654832ab6dcddc8e56999cc