### PR TITLE
Add doctor calendar page using vue-simple-calendar

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -34,6 +34,10 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
+        if ($request->user()->hasRole('medico')) {
+            return redirect()->intended('/medico');
+        }
+
         return redirect()->intended(RouteServiceProvider::HOME);
     }
 

--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -7,9 +7,24 @@ use App\Models\User;
 use App\Notifications\UpcomingSurgery;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
 
 class SurgeryController extends Controller
 {
+    /**
+     * Display a listing of the doctor's surgeries.
+     */
+    public function index(Request $request): Response
+    {
+        $surgeries = Surgery::where('doctor_id', $request->user()->id)
+            ->get(['id', 'room_number', 'start_time', 'end_time']);
+
+        return Inertia::render('Medico/Calendar', [
+            'surgeries' => $surgeries,
+        ]);
+    }
+
     /**
      * Store a newly created surgery in storage.
      */

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "postcss": "^8.4.31",
         "tailwindcss": "^3.2.1",
         "vite": "^5.0.0",
-        "vue": "^3.4.0"
+        "vue": "^3.4.0",
+        "vue-simple-calendar": "^5.0.0"
     }
 }

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -1,0 +1,33 @@
+<template>
+    <div class="p-4">
+        <CalendarView :events="events">
+            <template #event="{ event }">
+                <div class="p-1">
+                    {{ event.title }}
+                </div>
+            </template>
+        </CalendarView>
+    </div>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { CalendarView } from 'vue-simple-calendar';
+import 'vue-simple-calendar/dist/style.css';
+
+const props = defineProps({
+    surgeries: {
+        type: Array,
+        default: () => [],
+    },
+});
+
+const events = computed(() =>
+    props.surgeries.map((surgery) => ({
+        id: surgery.id,
+        startDate: new Date(surgery.start_time),
+        endDate: new Date(surgery.end_time),
+        title: `Sala ${surgery.room_number}`,
+    }))
+);
+</script>

--- a/routes/web.php
+++ b/routes/web.php
@@ -30,7 +30,7 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
 });
 
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
-Route::middleware(['auth', 'role:medico'])->get('/medico', fn () => 'medico area');
+Route::middleware(['auth', 'role:medico'])->get('/medico', [SurgeryController::class, 'index']);
 Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => 'enfermeiro area');
 Route::middleware(['auth', 'role:medico'])->post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
 


### PR DESCRIPTION
## Summary
- Add calendar page for doctors showing their surgeries via vue-simple-calendar
- Redirect doctors to /medico after login
- Provide surgeries data through new controller method and route

## Testing
- `npm install vue-simple-calendar --save` *(fails: 403 Forbidden)*
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*
- `php artisan test` *(skipped: vendor missing due to composer install failure)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2437a024832abe03c935946c9e03