### PR TITLE
Redirect doctors from dashboard and add navigation link

### DIFF
--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -32,6 +32,13 @@ const showingNavigationDropdown = ref(false);
                                 <NavLink :href="route('dashboard')" :active="route().current('dashboard')">
                                     Dashboard
                                 </NavLink>
+                                <NavLink
+                                    v-if="$page.props.auth.user.roles.includes('medico')"
+                                    :href="route('medico')"
+                                    :active="route().current('medico')"
+                                >
+                                    Medico
+                                </NavLink>
                             </div>
                         </div>
 
@@ -114,6 +121,13 @@ const showingNavigationDropdown = ref(false);
                     <div class="pt-2 pb-3 space-y-1">
                         <ResponsiveNavLink :href="route('dashboard')" :active="route().current('dashboard')">
                             Dashboard
+                        </ResponsiveNavLink>
+                        <ResponsiveNavLink
+                            v-if="$page.props.auth.user.roles.includes('medico')"
+                            :href="route('medico')"
+                            :active="route().current('medico')"
+                        >
+                            Medico
                         </ResponsiveNavLink>
                     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\ProfileController;
 use App\Http\Controllers\SurgeryController;
 use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
@@ -19,8 +20,10 @@ use Inertia\Inertia;
 
 Route::redirect('/', '/login');
 
-Route::get('/dashboard', function () {
-    return Inertia::render('Dashboard');
+Route::get('/dashboard', function (Request $request) {
+    return $request->user()->hasRole('medico')
+        ? redirect()->route('medico')
+        : Inertia::render('Dashboard');
 })->middleware(['auth', 'verified', 'role:adm|medico|enfermeiro'])->name('dashboard');
 
 Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
@@ -30,7 +33,7 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
 });
 
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
-Route::middleware(['auth', 'role:medico'])->get('/medico', [SurgeryController::class, 'index']);
+Route::middleware(['auth', 'role:medico'])->get('/medico', [SurgeryController::class, 'index'])->name('medico');
 Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => 'enfermeiro area');
 Route::middleware(['auth', 'role:medico'])->post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
 


### PR DESCRIPTION
## Summary
- Redirect doctors visiting `/dashboard` to `route('medico')`
- Expose named `medico` route and surface navigation links for doctors

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*
- `npm run build` *(fails: Rollup failed to resolve import "vue-simple-calendar" from /workspace/calendario/resources/js/Pages/Medico/Calendar.vue)*

------
https://chatgpt.com/codex/tasks/task_e_68bf287043e8832a83b916c06915278b