### PR TITLE
fix: correct calendar style import

### DIFF
--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -13,7 +13,7 @@
 <script setup>
 import { computed } from 'vue';
 import { CalendarView } from 'vue-simple-calendar';
-import 'vue-simple-calendar/dist/style.css';
+import 'vue-simple-calendar/dist/vue-simple-calendar.css';
 
 const props = defineProps({
     surgeries: {


### PR DESCRIPTION
## Summary
- fix calendar style import path for vue-simple-calendar

## Testing
- `npm run dev` *(fails: Missing dependency vue-simple-calendar)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2f4e8950832ab6db964bc3b99abf