### PR TITLE
Add custom calendar styling

### DIFF
--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -1,3 +1,5 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@import "./calendar.css";

--- a/resources/css/calendar.css
+++ b/resources/css/calendar.css
@@ -1,0 +1,16 @@
+/* Base calendar event styles */
+.event {
+    @apply rounded px-2 py-1 text-sm;
+}
+
+.event--scheduled {
+    @apply bg-yellow-200 text-yellow-800;
+}
+
+.event--confirmed {
+    @apply bg-green-200 text-green-800;
+}
+
+.event--conflict {
+    @apply bg-red-200 text-red-800;
+}

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -13,7 +13,6 @@
 <script setup>
 import { computed } from 'vue';
 import { CalendarView } from 'vue-simple-calendar';
-import 'vue-simple-calendar/dist/vue-simple-calendar.css';
 
 const props = defineProps({
     surgeries: {


### PR DESCRIPTION
## Summary
- add base calendar styles and event status classes
- import custom calendar CSS into app stylesheet
- remove vue-simple-calendar CSS import from Calendar page

## Testing
- `npm run build` *(fails: sh: 1: vite: not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c02756b25c832aa0a7fa2946ba65bb