### PR TITLE
Include status for calendar events

### DIFF
--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -2,7 +2,7 @@
     <div class="p-4">
         <CalendarView :events="events">
             <template #event="{ event }">
-                <div class="p-1">
+                <div class="event" :class="`event--${event.status}`">
                     {{ event.title }}
                 </div>
             </template>
@@ -28,6 +28,7 @@ const events = computed(() =>
         startDate: new Date(surgery.start_time),
         endDate: new Date(surgery.end_time),
         title: `Sala ${surgery.room_number}`,
+        status: surgery.status,
     }))
 );
 </script>


### PR DESCRIPTION
## Summary
- display calendar events with status-based styling
- expose backend-provided status in computed calendar events

## Testing
- `npm test` *(fails: Missing script "test")*
- `composer install` *(fails: inertiajs/inertia-laravel requirement conflict with PHP 8.4)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c02756b334832abe19d1061d77169e