### PR TITLE
Add patient details fields to surgeries

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -18,7 +18,7 @@ class SurgeryController extends Controller
     public function index(Request $request): Response
     {
         $surgeries = Surgery::where('doctor_id', $request->user()->id)
-            ->get(['id', 'room_number', 'start_time', 'end_time']);
+            ->get(['id', 'room_number', 'patient_name', 'surgery_type', 'expected_duration', 'start_time', 'end_time']);
 
         return Inertia::render('Medico/Calendar', [
             'surgeries' => $surgeries,
@@ -33,6 +33,9 @@ class SurgeryController extends Controller
         $data = $request->validate([
             'doctor_id' => ['required', 'exists:users,id'],
             'room_number' => ['required', 'integer'],
+            'patient_name' => ['required', 'string'],
+            'surgery_type' => ['required', 'string'],
+            'expected_duration' => ['required', 'integer'],
             'start_time' => ['required', 'date'],
             'end_time' => ['required', 'date', 'after:start_time'],
         ]);

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -14,6 +14,9 @@ class Surgery extends Model
     protected $fillable = [
         'doctor_id',
         'room_number',
+        'patient_name',
+        'surgery_type',
+        'expected_duration',
         'start_time',
         'end_time',
     ];

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -22,6 +22,9 @@ class SurgeryFactory extends Factory
         return [
             'doctor_id' => User::factory(),
             'room_number' => $this->faker->numberBetween(1, 10),
+            'patient_name' => $this->faker->name(),
+            'surgery_type' => $this->faker->word(),
+            'expected_duration' => $this->faker->numberBetween(30, 180),
             'start_time' => $start,
             'end_time' => $end,
         ];

--- a/database/migrations/2025_09_08_150000_create_surgeries_table.php
+++ b/database/migrations/2025_09_08_150000_create_surgeries_table.php
@@ -15,6 +15,9 @@ return new class extends Migration
             $table->id();
             $table->foreignId('doctor_id')->constrained('users')->cascadeOnDelete();
             $table->integer('room_number');
+            $table->string('patient_name');
+            $table->string('surgery_type');
+            $table->integer('expected_duration');
             $table->timestamp('start_time');
             $table->timestamp('end_time');
             $table->timestamps();

--- a/tests/Feature/SurgeryNotificationTest.php
+++ b/tests/Feature/SurgeryNotificationTest.php
@@ -29,6 +29,9 @@ class SurgeryNotificationTest extends TestCase
         $this->actingAs($doctor)->post('/surgeries', [
             'doctor_id' => $doctor->id,
             'room_number' => 1,
+            'patient_name' => 'John Doe',
+            'surgery_type' => 'Appendectomy',
+            'expected_duration' => 60,
             'start_time' => now()->addHour(),
             'end_time' => now()->addHours(2),
         ]);

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -26,6 +26,9 @@ class SurgeryTest extends TestCase
         $response = $this->post('/surgeries', [
             'doctor_id' => $doctor->id,
             'room_number' => 1,
+            'patient_name' => 'John Doe',
+            'surgery_type' => 'Appendectomy',
+            'expected_duration' => 60,
             'start_time' => now()->addDay(),
             'end_time' => now()->addDay()->addHour(),
         ]);
@@ -47,6 +50,9 @@ class SurgeryTest extends TestCase
             $response = $this->actingAs($user)->post('/surgeries', [
                 'doctor_id' => $doctor->id,
                 'room_number' => 1,
+                'patient_name' => 'John Doe',
+                'surgery_type' => 'Appendectomy',
+                'expected_duration' => 60,
                 'start_time' => now()->addDay(),
                 'end_time' => now()->addDay()->addHour(),
             ]);
@@ -63,6 +69,9 @@ class SurgeryTest extends TestCase
         $response = $this->actingAs($doctor)->post('/surgeries', [
             'doctor_id' => $doctor->id,
             'room_number' => 1,
+            'patient_name' => 'John Doe',
+            'surgery_type' => 'Appendectomy',
+            'expected_duration' => 60,
             'start_time' => now()->addDay(),
             'end_time' => now()->addDay()->addHour(),
         ]);
@@ -72,6 +81,9 @@ class SurgeryTest extends TestCase
         $this->assertDatabaseHas('surgeries', [
             'doctor_id' => $doctor->id,
             'room_number' => 1,
+            'patient_name' => 'John Doe',
+            'surgery_type' => 'Appendectomy',
+            'expected_duration' => 60,
         ]);
     }
 
@@ -82,6 +94,9 @@ class SurgeryTest extends TestCase
 
         $existing = Surgery::factory()->create([
             'room_number' => 1,
+            'patient_name' => 'John Doe',
+            'surgery_type' => 'Appendectomy',
+            'expected_duration' => 60,
             'start_time' => now()->addDay(),
             'end_time' => now()->addDay()->addHour(),
         ]);
@@ -89,6 +104,9 @@ class SurgeryTest extends TestCase
         $response = $this->actingAs($doctor)->post('/surgeries', [
             'doctor_id' => $doctor->id,
             'room_number' => 1,
+            'patient_name' => 'John Doe',
+            'surgery_type' => 'Appendectomy',
+            'expected_duration' => 60,
             'start_time' => $existing->start_time->copy()->addMinutes(30),
             'end_time' => $existing->end_time->copy()->addMinutes(30),
         ]);
@@ -106,6 +124,9 @@ class SurgeryTest extends TestCase
         $response = $this->actingAs($doctor)->post('/surgeries', [
             'doctor_id' => $otherDoctor->id,
             'room_number' => 1,
+            'patient_name' => 'John Doe',
+            'surgery_type' => 'Appendectomy',
+            'expected_duration' => 60,
             'start_time' => now()->addDay(),
             'end_time' => now()->addDay()->addHour(),
         ]);


### PR DESCRIPTION
## Summary
- add patient_name, surgery_type, and expected_duration columns to surgeries
- allow mass assignment and validation of new fields
- cover new fields in factories and feature tests

## Testing
- `php -l database/migrations/2025_09_08_150000_create_surgeries_table.php`
- `php -l app/Models/Surgery.php`
- `php -l app/Http/Controllers/SurgeryController.php`
- `php -l database/factories/SurgeryFactory.php`
- `php -l tests/Feature/SurgeryTest.php`
- `php -l tests/Feature/SurgeryNotificationTest.php`
- `composer install --no-interaction --ignore-platform-reqs` *(failed: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c02756a6dc832a9948a5ef041bff89