### PR TITLE
Track audit actors in surgery logs

### DIFF
--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -43,6 +43,7 @@ class Surgery extends Model
                 'room_number' => $surgery->room_number,
                 'start_time' => $surgery->start_time,
                 'end_time' => $surgery->end_time,
+                'created_by' => auth()->id(),
             ]);
         });
 
@@ -52,6 +53,7 @@ class Surgery extends Model
                 'room_number' => $surgery->room_number,
                 'start_time' => $surgery->start_time,
                 'end_time' => $surgery->end_time,
+                'confirmed_by' => auth()->id(),
             ]);
         });
 
@@ -61,6 +63,7 @@ class Surgery extends Model
                 'room_number' => $surgery->room_number,
                 'start_time' => $surgery->start_time,
                 'end_time' => $surgery->end_time,
+                'confirmed_by' => auth()->id(),
             ]);
         });
     }

--- a/app/Models/SurgeryAudit.php
+++ b/app/Models/SurgeryAudit.php
@@ -13,6 +13,8 @@ class SurgeryAudit extends Model
     protected $fillable = [
         'surgery_id',
         'doctor_id',
+        'created_by',
+        'confirmed_by',
         'room_number',
         'start_time',
         'end_time',

--- a/database/migrations/2025_09_08_160000_create_surgery_audits_table.php
+++ b/database/migrations/2025_09_08_160000_create_surgery_audits_table.php
@@ -15,6 +15,8 @@ return new class extends Migration
             $table->id();
             $table->unsignedBigInteger('surgery_id');
             $table->unsignedBigInteger('doctor_id');
+            $table->foreignId('created_by')->nullable()->constrained('users');
+            $table->foreignId('confirmed_by')->nullable()->constrained('users');
             $table->integer('room_number');
             $table->timestamp('start_time');
             $table->timestamp('end_time');

--- a/tests/Feature/SurgeryAuditTest.php
+++ b/tests/Feature/SurgeryAuditTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature;
 
 use App\Models\Surgery;
+use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
@@ -12,12 +13,50 @@ class SurgeryAuditTest extends TestCase
 
     public function test_audit_entry_created_when_surgery_scheduled(): void
     {
+        $user = User::factory()->create();
+        $this->actingAs($user);
+
         $surgery = Surgery::factory()->create();
 
         $this->assertDatabaseHas('surgery_audits', [
             'surgery_id' => $surgery->id,
             'doctor_id' => $surgery->doctor_id,
             'room_number' => $surgery->room_number,
+            'created_by' => $user->id,
+            'confirmed_by' => null,
+        ]);
+    }
+
+    public function test_audit_entry_records_confirmed_by_on_update(): void
+    {
+        $creator = User::factory()->create();
+        $this->actingAs($creator);
+        $surgery = Surgery::factory()->create();
+
+        $confirmer = User::factory()->create();
+        $this->actingAs($confirmer);
+        $surgery->update(['room_number' => 99]);
+
+        $this->assertDatabaseHas('surgery_audits', [
+            'surgery_id' => $surgery->id,
+            'room_number' => 99,
+            'confirmed_by' => $confirmer->id,
+        ]);
+    }
+
+    public function test_audit_entry_records_confirmed_by_on_delete(): void
+    {
+        $creator = User::factory()->create();
+        $this->actingAs($creator);
+        $surgery = Surgery::factory()->create();
+
+        $deleter = User::factory()->create();
+        $this->actingAs($deleter);
+        $surgery->delete();
+
+        $this->assertDatabaseHas('surgery_audits', [
+            'surgery_id' => $surgery->id,
+            'confirmed_by' => $deleter->id,
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- add `created_by` and `confirmed_by` user references to surgery audit migration
- record creating and confirming users in `Surgery` model callbacks
- test that audit entries capture creating and confirming users

## Testing
- `composer install --ignore-platform-reqs` *(fails: Failed to download symfony/polyfill-ctype, CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c02759e228832a9eb3ce6ff1551235