### PR TITLE
Add nurse-confirmed surgeries

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -57,5 +57,17 @@ class SurgeryController extends Controller
 
         return back();
     }
+
+    /**
+     * Confirm a scheduled surgery.
+     */
+    public function confirm(Request $request, Surgery $surgery): RedirectResponse
+    {
+        $surgery->status = 'confirmed';
+        $surgery->confirmed_by = $request->user()->id;
+        $surgery->save();
+
+        return back();
+    }
 }
 

--- a/database/migrations/2025_09_08_170000_add_status_and_confirmed_by_to_surgeries_table.php
+++ b/database/migrations/2025_09_08_170000_add_status_and_confirmed_by_to_surgeries_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->string('status')->default('scheduled');
+            $table->foreignId('confirmed_by')->nullable()->constrained('users')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->dropColumn('status');
+            $table->dropForeign(['confirmed_by']);
+            $table->dropColumn('confirmed_by');
+        });
+    }
+};

--- a/resources/js/Pages/Enfermeiro/Confirm.vue
+++ b/resources/js/Pages/Enfermeiro/Confirm.vue
@@ -1,0 +1,32 @@
+<script setup>
+import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue';
+import { Head, router } from '@inertiajs/vue3';
+import { ref } from 'vue';
+
+const surgeryId = ref('');
+
+const confirmSurgery = () => {
+    if (surgeryId.value) {
+        router.post(route('surgeries.confirm', surgeryId.value));
+    }
+};
+</script>
+
+<template>
+    <Head title="Confirm Surgery" />
+
+    <AuthenticatedLayout>
+        <template #header>
+            <h2 class="font-semibold text-xl text-gray-800 leading-tight">Confirm Surgery</h2>
+        </template>
+
+        <div class="py-12">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
+                <div class="bg-white overflow-hidden shadow-sm sm:rounded-lg p-6 flex items-center">
+                    <input v-model="surgeryId" type="text" placeholder="Surgery ID" class="border rounded px-2 py-1" />
+                    <button @click="confirmSurgery" class="ml-2 bg-blue-500 text-white px-4 py-2 rounded">Confirm</button>
+                </div>
+            </div>
+        </div>
+    </AuthenticatedLayout>
+</template>

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,7 +34,8 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
 
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
 Route::middleware(['auth', 'role:medico'])->get('/medico', [SurgeryController::class, 'index'])->name('medico');
-Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => 'enfermeiro area');
+Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => Inertia::render('Enfermeiro/Confirm'));
 Route::middleware(['auth', 'role:medico'])->post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
+Route::middleware(['auth', 'role:enfermeiro'])->post('/surgeries/{surgery}/confirm', [SurgeryController::class, 'confirm'])->name('surgeries.confirm');
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/SurgeryConfirmationTest.php
+++ b/tests/Feature/SurgeryConfirmationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Surgery;
+use App\Models\User;
+use Database\Seeders\RoleSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SurgeryConfirmationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->seed(RoleSeeder::class);
+    }
+
+    public function test_guest_is_redirected_when_confirming_surgery(): void
+    {
+        $surgery = Surgery::factory()->create();
+
+        $response = $this->post("/surgeries/{$surgery->id}/confirm");
+
+        $response->assertRedirect('/login');
+    }
+
+    public function test_non_enfermeiro_users_cannot_confirm_surgery(): void
+    {
+        $surgery = Surgery::factory()->create();
+
+        foreach ([null, 'adm', 'medico'] as $role) {
+            $user = User::factory()->create();
+            if ($role) {
+                $user->assignRole($role);
+            }
+
+            $response = $this->actingAs($user)->post("/surgeries/{$surgery->id}/confirm");
+
+            $response->assertForbidden();
+        }
+    }
+
+    public function test_enfermeiro_can_confirm_surgery(): void
+    {
+        $surgery = Surgery::factory()->create();
+
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        $response = $this->actingAs($nurse)->from('/enfermeiro')->post("/surgeries/{$surgery->id}/confirm");
+
+        $response->assertRedirect('/enfermeiro');
+
+        $this->assertDatabaseHas('surgeries', [
+            'id' => $surgery->id,
+            'status' => 'confirmed',
+            'confirmed_by' => $nurse->id,
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
- allow nurses to confirm surgeries via new protected route
- track status and who confirmed a surgery
- add simple nurse UI and feature tests

## Testing
- `php artisan test` *(fails: Failed to open required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68c0275c97f0832ab37f9f87a8665e7f