### PR TITLE
Restrict surgery room numbers to range 1-9

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -32,7 +32,7 @@ class SurgeryController extends Controller
     {
         $data = $request->validate([
             'doctor_id' => ['required', 'exists:users,id'],
-            'room_number' => ['required', 'integer'],
+            'room_number' => ['required', 'integer', 'between:1,9'],
             'start_time' => ['required', 'date'],
             'end_time' => ['required', 'date', 'after:start_time'],
         ]);

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -21,7 +21,7 @@ class SurgeryFactory extends Factory
 
         return [
             'doctor_id' => User::factory(),
-            'room_number' => $this->faker->numberBetween(1, 10),
+            'room_number' => $this->faker->numberBetween(1, 9),
             'start_time' => $start,
             'end_time' => $end,
         ];

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -1,5 +1,14 @@
 <template>
     <div class="p-4">
+        <form class="mb-4">
+            <label for="room_number" class="mr-2">Sala</label>
+            <select id="room_number" name="room_number" class="border rounded p-1">
+                <option v-for="room in rooms" :key="room" :value="room">
+                    Sala {{ room }}
+                </option>
+            </select>
+        </form>
+
         <CalendarView :events="events">
             <template #event="{ event }">
                 <div class="p-1">
@@ -30,4 +39,6 @@ const events = computed(() =>
         title: `Sala ${surgery.room_number}`,
     }))
 );
+
+const rooms = Array.from({ length: 9 }, (_, i) => i + 1);
 </script>

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -112,5 +112,22 @@ class SurgeryTest extends TestCase
 
         $response->assertSessionHasErrors('doctor_id');
     }
+
+    public function test_room_number_outside_valid_range_is_rejected(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        foreach ([0, 10] as $invalidRoom) {
+            $response = $this->actingAs($doctor)->post('/surgeries', [
+                'doctor_id' => $doctor->id,
+                'room_number' => $invalidRoom,
+                'start_time' => now()->addDay(),
+                'end_time' => now()->addDay()->addHour(),
+            ]);
+
+            $response->assertSessionHasErrors('room_number');
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- enforce surgery room numbers to be between 1 and 9 in controller
- expose nine room options on calendar form
- test rejection of room numbers outside the allowed range

## Testing
- `composer install --ignore-platform-reqs` *(fails: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed to open stream: vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68c0275f4140832abe7f4e81b46d1c84