### PR TITLE
Track surgery creators and confirmations

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -49,11 +49,26 @@ class SurgeryController extends Controller
             ]);
         }
 
+        $data['created_by'] = $request->user()->id;
+
         $surgery = Surgery::create($data);
 
         if ($doctor = User::find($surgery->doctor_id)) {
             $doctor->notify(new UpcomingSurgery($surgery->start_time));
         }
+
+        return back();
+    }
+
+    /**
+     * Confirm a scheduled surgery.
+     */
+    public function confirm(Request $request, Surgery $surgery): RedirectResponse
+    {
+        $surgery->update([
+            'status' => 'confirmed',
+            'confirmed_by' => $request->user()->id,
+        ]);
 
         return back();
     }

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -13,9 +13,16 @@ class Surgery extends Model
 
     protected $fillable = [
         'doctor_id',
+        'created_by',
+        'confirmed_by',
+        'status',
         'room_number',
         'start_time',
         'end_time',
+    ];
+
+    protected $attributes = [
+        'status' => 'scheduled',
     ];
 
     /**

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -21,6 +21,8 @@ class SurgeryFactory extends Factory
 
         return [
             'doctor_id' => User::factory(),
+            'created_by' => User::factory(),
+            'status' => 'scheduled',
             'room_number' => $this->faker->numberBetween(1, 10),
             'start_time' => $start,
             'end_time' => $end,

--- a/database/migrations/2025_09_08_150000_create_surgeries_table.php
+++ b/database/migrations/2025_09_08_150000_create_surgeries_table.php
@@ -14,6 +14,9 @@ return new class extends Migration
         Schema::create('surgeries', function (Blueprint $table) {
             $table->id();
             $table->foreignId('doctor_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('created_by')->constrained('users')->cascadeOnDelete();
+            $table->foreignId('confirmed_by')->nullable()->constrained('users')->cascadeOnDelete();
+            $table->enum('status', ['scheduled', 'confirmed'])->default('scheduled');
             $table->integer('room_number');
             $table->timestamp('start_time');
             $table->timestamp('end_time');

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,5 +36,6 @@ Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
 Route::middleware(['auth', 'role:medico'])->get('/medico', [SurgeryController::class, 'index'])->name('medico');
 Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => 'enfermeiro area');
 Route::middleware(['auth', 'role:medico'])->post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
+Route::middleware(['auth', 'role:enfermeiro'])->patch('/surgeries/{surgery}/confirm', [SurgeryController::class, 'confirm'])->name('surgeries.confirm');
 
 require __DIR__.'/auth.php';

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -72,6 +72,7 @@ class SurgeryTest extends TestCase
         $this->assertDatabaseHas('surgeries', [
             'doctor_id' => $doctor->id,
             'room_number' => 1,
+            'created_by' => $doctor->id,
         ]);
     }
 
@@ -111,6 +112,28 @@ class SurgeryTest extends TestCase
         ]);
 
         $response->assertSessionHasErrors('doctor_id');
+    }
+
+    public function test_enfermeiro_can_confirm_surgery(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+        $surgery = Surgery::factory()->create([
+            'doctor_id' => $doctor->id,
+        ]);
+
+        $nurse = User::factory()->create();
+        $nurse->assignRole('enfermeiro');
+
+        $response = $this->actingAs($nurse)->patch("/surgeries/{$surgery->id}/confirm");
+
+        $response->assertRedirect('/');
+
+        $this->assertDatabaseHas('surgeries', [
+            'id' => $surgery->id,
+            'confirmed_by' => $nurse->id,
+            'status' => 'confirmed',
+        ]);
     }
 }
 


### PR DESCRIPTION
## Summary
- add creator and confirmer tracking to surgeries with status field
- default status to scheduled and allow confirmation
- cover creation and confirmation of surgeries in tests

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0)*
- `php artisan test` *(fails: failed opening required '/workspace/calendario/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c027627214832a8b0a82aa3bd55ce1