### PR TITLE
Restrict surgery room numbers to 1-9

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -32,7 +32,7 @@ class SurgeryController extends Controller
     {
         $data = $request->validate([
             'doctor_id' => ['required', 'exists:users,id'],
-            'room_number' => ['required', 'integer'],
+            'room_number' => ['required', 'integer', 'between:1,9'],
             'patient_name' => ['required', 'string'],
             'surgery_type' => ['required', 'string'],
             'expected_duration' => ['required', 'integer'],

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -21,7 +21,7 @@ class SurgeryFactory extends Factory
 
         return [
             'doctor_id' => User::factory(),
-            'room_number' => $this->faker->numberBetween(1, 10),
+            'room_number' => $this->faker->numberBetween(1, 9),
             'patient_name' => $this->faker->name(),
             'surgery_type' => $this->faker->word(),
             'expected_duration' => $this->faker->numberBetween(30, 180),

--- a/resources/js/Components/RoomNumberSelect.vue
+++ b/resources/js/Components/RoomNumberSelect.vue
@@ -1,0 +1,15 @@
+<template>
+    <select :value="modelValue" @change="$emit('update:modelValue', Number($event.target.value))">
+        <option v-for="n in 9" :key="n" :value="n">{{ n }}</option>
+    </select>
+</template>
+
+<script setup>
+const props = defineProps({
+    modelValue: {
+        type: Number,
+        default: 1,
+    },
+});
+const emit = defineEmits(['update:modelValue']);
+</script>

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -1,5 +1,6 @@
 <template>
     <div class="p-4">
+        <RoomNumberSelect v-model="selectedRoom" class="mb-4" />
         <CalendarView :events="events">
             <template #event="{ event }">
                 <div class="event" :class="`event--${event.status}`">
@@ -11,8 +12,9 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { CalendarView } from 'vue-simple-calendar';
+import RoomNumberSelect from '@/Components/RoomNumberSelect.vue';
 
 const props = defineProps({
     surgeries: {
@@ -30,4 +32,6 @@ const events = computed(() =>
         status: surgery.status,
     }))
 );
+
+const selectedRoom = ref(1);
 </script>

--- a/tests/Feature/SurgeryAuditTest.php
+++ b/tests/Feature/SurgeryAuditTest.php
@@ -35,11 +35,11 @@ class SurgeryAuditTest extends TestCase
 
         $confirmer = User::factory()->create();
         $this->actingAs($confirmer);
-        $surgery->update(['room_number' => 99]);
+        $surgery->update(['room_number' => 9]);
 
         $this->assertDatabaseHas('surgery_audits', [
             'surgery_id' => $surgery->id,
-            'room_number' => 99,
+            'room_number' => 9,
             'confirmed_by' => $confirmer->id,
         ]);
     }

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -133,5 +133,27 @@ class SurgeryTest extends TestCase
 
         $response->assertSessionHasErrors('doctor_id');
     }
+
+    public function test_room_number_must_be_between_one_and_nine(): void
+    {
+        $doctor = User::factory()->create();
+        $doctor->assignRole('medico');
+
+        $this->actingAs($doctor);
+
+        foreach ([0, 10] as $room) {
+            $response = $this->post('/surgeries', [
+                'doctor_id' => $doctor->id,
+                'room_number' => $room,
+                'patient_name' => 'John Doe',
+                'surgery_type' => 'Appendectomy',
+                'expected_duration' => 60,
+                'start_time' => now()->addDay(),
+                'end_time' => now()->addDay()->addHour(),
+            ]);
+
+            $response->assertSessionHasErrors('room_number');
+        }
+    }
 }
 


### PR DESCRIPTION
## Summary
- Validate `room_number` within 1-9 in `SurgeryController`
- Limit surgery factory and add Vue room selector component with options 1-9
- Add feature test ensuring out-of-range room numbers are rejected

## Testing
- `composer install` (failed: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.12) does not satisfy that requirement)
- `composer update` (failed: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)
- `npm install` (failed: 403 Forbidden - GET https://registry.npmjs.org/terser)


------
https://chatgpt.com/codex/tasks/task_e_68c02d41d974832a9966931725a0e60d