### PR TITLE
feat: track surgery creator

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -40,6 +40,9 @@ class SurgeryController extends Controller
             'end_time' => ['required', 'date', 'after:start_time'],
         ]);
 
+        $data['created_by'] = $request->user()->id;
+        $data['status'] = 'scheduled';
+
         if ($request->user()->id !== $data['doctor_id']) {
             return back()->withErrors([
                 'doctor_id' => 'Doctors can only schedule surgeries for themselves.',

--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -19,6 +19,8 @@ class Surgery extends Model
         'expected_duration',
         'start_time',
         'end_time',
+        'status',
+        'created_by',
     ];
 
     /**

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -27,6 +27,7 @@ class SurgeryFactory extends Factory
             'expected_duration' => $this->faker->numberBetween(30, 180),
             'start_time' => $start,
             'end_time' => $end,
+            'created_by' => User::factory(),
         ];
     }
 }

--- a/database/migrations/2025_09_08_180000_add_created_by_to_surgeries_table.php
+++ b/database/migrations/2025_09_08_180000_add_created_by_to_surgeries_table.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->foreignId('created_by')->constrained('users')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('surgeries', function (Blueprint $table) {
+            $table->dropForeign(['created_by']);
+            $table->dropColumn('created_by');
+        });
+    }
+};

--- a/tests/Feature/SurgeryConfirmationTest.php
+++ b/tests/Feature/SurgeryConfirmationTest.php
@@ -45,7 +45,11 @@ class SurgeryConfirmationTest extends TestCase
 
     public function test_enfermeiro_can_confirm_surgery(): void
     {
-        $surgery = Surgery::factory()->create();
+        $doctor = User::factory()->create();
+        $surgery = Surgery::factory()->create([
+            'doctor_id' => $doctor->id,
+            'created_by' => $doctor->id,
+        ]);
 
         $nurse = User::factory()->create();
         $nurse->assignRole('enfermeiro');
@@ -58,6 +62,7 @@ class SurgeryConfirmationTest extends TestCase
             'id' => $surgery->id,
             'status' => 'confirmed',
             'confirmed_by' => $nurse->id,
+            'created_by' => $doctor->id,
         ]);
     }
 }

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -84,6 +84,9 @@ class SurgeryTest extends TestCase
             'patient_name' => 'John Doe',
             'surgery_type' => 'Appendectomy',
             'expected_duration' => 60,
+            'created_by' => $doctor->id,
+            'status' => 'scheduled',
+            'confirmed_by' => null,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add `created_by` relationship to surgeries
- set `created_by` and default `status` when storing surgeries
- ensure tests cover `created_by` and `confirmed_by`

## Testing
- `composer install --no-interaction --no-progress --no-scripts` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.12) does not satisfy that requirement)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c02d485f38832a9a21acdfed25de86