### PR TITLE
refactor: import vue-simple-calendar from source

### DIFF
--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -16,7 +16,7 @@
 
 <script setup>
 import { computed, ref } from 'vue';
-import { CalendarView } from 'vue-simple-calendar';
+import CalendarView from 'vue-simple-calendar/src/CalendarView.vue';
 import RoomNumberSelect from '@/Components/RoomNumberSelect.vue';
 
 const props = defineProps({

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,7 +18,4 @@ export default defineConfig({
             },
         }),
     ],
-    optimizeDeps: {
-        include: ['vue-simple-calendar'],
-    },
 });


### PR DESCRIPTION
## Summary
- import `CalendarView` directly from vue-simple-calendar source
- drop vite `optimizeDeps` prebundle for vue-simple-calendar

## Testing
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_68c032103fe0832a9c469e097451a93f