### PR TITLE
Replace vue-simple-calendar with FullCalendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
         "tailwindcss": "^3.2.1",
         "vite": "^5.0.0",
         "vue": "^3.4.0",
-        "vue-simple-calendar": "^5.0.1"
+        "@fullcalendar/core": "^6.1.10",
+        "@fullcalendar/daygrid": "^6.1.10",
+        "@fullcalendar/interaction": "^6.1.10",
+        "@fullcalendar/timegrid": "^6.1.10",
+        "@fullcalendar/vue3": "^6.1.10"
     }
 }

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -1,22 +1,19 @@
 <template>
     <div class="p-4">
         <RoomNumberSelect v-model="selectedRoom" class="mb-4" />
-        <CalendarView :events="events">
-            <template #event="{ event }">
-                <div
-                    class="event"
-                    :class="event.status === 'conflict' ? 'event--conflict' : `event--${event.status}`"
-                >
-                    {{ event.title }}
-                </div>
-            </template>
-        </CalendarView>
+        <FullCalendar :options="options" />
     </div>
 </template>
 
 <script setup>
 import { computed, ref } from 'vue';
-import CalendarView from 'vue-simple-calendar/src/CalendarView.vue';
+import FullCalendar from '@fullcalendar/vue3';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+import timeGridPlugin from '@fullcalendar/timegrid';
+import '@fullcalendar/core/index.css';
+import '@fullcalendar/daygrid/index.css';
+import '@fullcalendar/timegrid/index.css';
 import RoomNumberSelect from '@/Components/RoomNumberSelect.vue';
 
 const props = defineProps({
@@ -29,12 +26,22 @@ const props = defineProps({
 const events = computed(() =>
     props.surgeries.map((surgery) => ({
         id: surgery.id,
-        startDate: new Date(surgery.start_time),
-        endDate: new Date(surgery.end_time),
+        start: surgery.start_time,
+        end: surgery.end_time,
         title: `Sala ${surgery.room_number}`,
-        status: surgery.status,
+        extendedProps: { status: surgery.status },
     }))
 );
+
+const options = computed(() => ({
+    plugins: [dayGridPlugin, timeGridPlugin, interactionPlugin],
+    initialView: 'dayGridMonth',
+    events: events.value,
+    eventClassNames({ event }) {
+        const status = event.extendedProps.status;
+        return ['event', status === 'conflict' ? 'event--conflict' : `event--${status}`];
+    },
+}));
 
 const selectedRoom = ref(1);
 </script>


### PR DESCRIPTION
## Summary
- replace vue-simple-calendar with FullCalendar Vue 3 components
- map surgery status to calendar event classes via eventClassNames

## Testing
- `npm install` *(fails: 403 Forbidden for @fullcalendar/core)*
- `npm run build` *(fails: vite not found)*
- `php artisan test` *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c034151acc832a84a3e45f89faa7da