### PR TITLE
fix: use FullCalendar plugin styles only

### DIFF
--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -11,7 +11,6 @@ import FullCalendar from '@fullcalendar/vue3';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import timeGridPlugin from '@fullcalendar/timegrid';
-import '@fullcalendar/core/index.css';
 import '@fullcalendar/daygrid/index.css';
 import '@fullcalendar/timegrid/index.css';
 import RoomNumberSelect from '@/Components/RoomNumberSelect.vue';


### PR DESCRIPTION
## Summary
- remove `@fullcalendar/core` CSS import
- rely on plugin-specific CSS imports for FullCalendar

## Testing
- `npm ci` *(fails: 403 Forbidden for @fullcalendar/core)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0361115bc832aadd3d842af74a8d9