### PR TITLE
Import FullCalendar core styles

### DIFF
--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -11,6 +11,7 @@ import FullCalendar from '@fullcalendar/vue3';
 import dayGridPlugin from '@fullcalendar/daygrid';
 import interactionPlugin from '@fullcalendar/interaction';
 import timeGridPlugin from '@fullcalendar/timegrid';
+import '@fullcalendar/core/index.css';
 import '@fullcalendar/daygrid/index.css';
 import '@fullcalendar/timegrid/index.css';
 import RoomNumberSelect from '@/Components/RoomNumberSelect.vue';


### PR DESCRIPTION
## Summary
- add `@fullcalendar/core` CSS import so FullCalendar components have base styles

## Testing
- `npm run build` *(fails: sh: 1: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c037ff1bcc832aab49444fffe89f49