### PR TITLE
Filter surgeries by room in calendar

### DIFF
--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -21,15 +21,18 @@ const props = defineProps({
         default: () => [],
     },
 });
+const selectedRoom = ref(1);
 
 const events = computed(() =>
-    props.surgeries.map((surgery) => ({
-        id: surgery.id,
-        start: surgery.start_time,
-        end: surgery.end_time,
-        title: `Sala ${surgery.room_number}`,
-        extendedProps: { status: surgery.status },
-    }))
+    props.surgeries
+        .filter((surgery) => surgery.room_number === selectedRoom.value)
+        .map((surgery) => ({
+            id: surgery.id,
+            start: surgery.start_time,
+            end: surgery.end_time,
+            title: `Sala ${surgery.room_number}`,
+            extendedProps: { status: surgery.status },
+        }))
 );
 
 const options = computed(() => ({
@@ -41,6 +44,4 @@ const options = computed(() => ({
         return ['event', status === 'conflict' ? 'event--conflict' : `event--${status}`];
     },
 }));
-
-const selectedRoom = ref(1);
 </script>


### PR DESCRIPTION
## Summary
- Filter surgeries by selected room in Medico calendar view
- Ensure selected room ref is declared before computing events so calendar updates

## Testing
- `npm run build` *(fails: vite: not found)*
- `npm install --no-progress --no-audit --no-fund` *(fails: ENOTEMPTY rename '/workspace/calendario/node_modules/chokidar')*


------
https://chatgpt.com/codex/tasks/task_e_68c038008f8c832aa7c48c5eee616aef