### PR TITLE
Replace medico and enfermeiro routes with unified surgeries endpoint

### DIFF
--- a/app/Http/Controllers/Auth/AuthenticatedSessionController.php
+++ b/app/Http/Controllers/Auth/AuthenticatedSessionController.php
@@ -34,8 +34,8 @@ class AuthenticatedSessionController extends Controller
 
         $request->session()->regenerate();
 
-        if ($request->user()->hasRole('medico')) {
-            return redirect()->intended('/medico');
+        if ($request->user()->hasAnyRole(['medico', 'enfermeiro'])) {
+            return redirect()->intended(route('surgeries.index'));
         }
 
         return redirect()->intended(RouteServiceProvider::HOME);

--- a/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/resources/js/Layouts/AuthenticatedLayout.vue
@@ -33,11 +33,11 @@ const showingNavigationDropdown = ref(false);
                                     Dashboard
                                 </NavLink>
                                 <NavLink
-                                    v-if="$page.props.auth.user.roles.includes('medico')"
-                                    :href="route('medico')"
-                                    :active="route().current('medico')"
+                                    v-if="$page.props.auth.user.roles.some(role => ['medico', 'enfermeiro'].includes(role))"
+                                    :href="route('surgeries.index')"
+                                    :active="route().current('surgeries.index')"
                                 >
-                                    Medico
+                                    Surgeries
                                 </NavLink>
                             </div>
                         </div>
@@ -123,11 +123,11 @@ const showingNavigationDropdown = ref(false);
                             Dashboard
                         </ResponsiveNavLink>
                         <ResponsiveNavLink
-                            v-if="$page.props.auth.user.roles.includes('medico')"
-                            :href="route('medico')"
-                            :active="route().current('medico')"
+                            v-if="$page.props.auth.user.roles.some(role => ['medico', 'enfermeiro'].includes(role))"
+                            :href="route('surgeries.index')"
+                            :active="route().current('surgeries.index')"
                         >
-                            Medico
+                            Surgeries
                         </ResponsiveNavLink>
                     </div>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,8 +21,8 @@ use Inertia\Inertia;
 Route::redirect('/', '/login');
 
 Route::get('/dashboard', function (Request $request) {
-    return $request->user()->hasRole('medico')
-        ? redirect()->route('medico')
+    return $request->user()->hasAnyRole(['medico', 'enfermeiro'])
+        ? redirect()->route('surgeries.index')
         : Inertia::render('Dashboard');
 })->middleware(['auth', 'verified', 'role:adm|medico|enfermeiro'])->name('dashboard');
 
@@ -33,8 +33,9 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
 });
 
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
-Route::middleware(['auth', 'role:medico'])->get('/medico', [SurgeryController::class, 'index'])->name('medico');
-Route::middleware(['auth', 'role:enfermeiro'])->get('/enfermeiro', fn () => Inertia::render('Enfermeiro/Confirm'));
+Route::middleware(['auth', 'role:medico|enfermeiro'])->get('/surgeries', [SurgeryController::class, 'index'])->name('surgeries.index');
+Route::redirect('/medico', '/surgeries')->middleware(['auth', 'role:medico']);
+Route::redirect('/enfermeiro', '/surgeries')->middleware(['auth', 'role:enfermeiro']);
 Route::middleware(['auth', 'role:medico'])->post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
 Route::middleware(['auth', 'role:enfermeiro'])->post('/surgeries/{surgery}/confirm', [SurgeryController::class, 'confirm'])->name('surgeries.confirm');
 

--- a/tests/Feature/RoleAccessTest.php
+++ b/tests/Feature/RoleAccessTest.php
@@ -23,8 +23,7 @@ class RoleAccessTest extends TestCase
         $user->assignRole('adm');
 
         $this->actingAs($user)->get('/admin')->assertOk();
-        $this->actingAs($user)->get('/medico')->assertForbidden();
-        $this->actingAs($user)->get('/enfermeiro')->assertForbidden();
+        $this->actingAs($user)->get('/surgeries')->assertForbidden();
     }
 
     public function test_medico_access()
@@ -32,9 +31,8 @@ class RoleAccessTest extends TestCase
         $user = User::factory()->create();
         $user->assignRole('medico');
 
-        $this->actingAs($user)->get('/medico')->assertOk();
+        $this->actingAs($user)->get('/surgeries')->assertOk();
         $this->actingAs($user)->get('/admin')->assertForbidden();
-        $this->actingAs($user)->get('/enfermeiro')->assertForbidden();
     }
 
     public function test_enfermeiro_access()
@@ -42,8 +40,7 @@ class RoleAccessTest extends TestCase
         $user = User::factory()->create();
         $user->assignRole('enfermeiro');
 
-        $this->actingAs($user)->get('/enfermeiro')->assertOk();
+        $this->actingAs($user)->get('/surgeries')->assertOk();
         $this->actingAs($user)->get('/admin')->assertForbidden();
-        $this->actingAs($user)->get('/medico')->assertForbidden();
     }
 }

--- a/tests/Feature/SurgeryConfirmationTest.php
+++ b/tests/Feature/SurgeryConfirmationTest.php
@@ -54,9 +54,9 @@ class SurgeryConfirmationTest extends TestCase
         $nurse = User::factory()->create();
         $nurse->assignRole('enfermeiro');
 
-        $response = $this->actingAs($nurse)->from('/enfermeiro')->post("/surgeries/{$surgery->id}/confirm");
+        $response = $this->actingAs($nurse)->from('/surgeries')->post("/surgeries/{$surgery->id}/confirm");
 
-        $response->assertRedirect('/enfermeiro');
+        $response->assertRedirect('/surgeries');
 
         $this->assertDatabaseHas('surgeries', [
             'id' => $surgery->id,

--- a/tests/Feature/SurgeryTest.php
+++ b/tests/Feature/SurgeryTest.php
@@ -139,7 +139,7 @@ class SurgeryTest extends TestCase
             'end_time' => $surgeryOne->end_time->copy()->addMinutes(30),
         ]);
 
-        $response = $this->actingAs($doctor)->get('/medico');
+        $response = $this->actingAs($doctor)->get('/surgeries');
 
         $response->assertInertia(fn (Assert $page) =>
             $page->component('Medico/Calendar')


### PR DESCRIPTION
## Summary
- Route `/surgeries` now lists surgeries for both medics and nurses
- Redirect obsolete `/medico` and `/enfermeiro` paths to `/surgeries`
- Adjust login, dashboard, navigation, and tests for new route

## Testing
- `php artisan test` *(fails: require(/workspace/calendario/vendor/autoload.php): Failed to open stream)*

------
https://chatgpt.com/codex/tasks/task_e_68c057947db0832a866fbed6664794d7