### PR TITLE
Ensure consistent surgery status labels

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -19,7 +19,10 @@ class SurgeryController extends Controller
         $surgeries = Surgery::with(['creator', 'confirmer'])->paginate(15);
 
         $surgeries->getCollection()->transform(function (Surgery $surgery) {
-            $surgery->status = $surgery->confirmed_by ? 'confirmado' : 'agendado';
+            $surgery->status = $surgery->is_conflict
+                ? 'conflito'
+                : ($surgery->confirmed_by ? 'confirmado' : 'agendado');
+
             return $surgery;
         });
 
@@ -64,7 +67,7 @@ class SurgeryController extends Controller
         $surgery->confirmed_by = $request->user()->id;
         $surgery->save();
 
-        $surgery->status = 'confirmado';
+        $surgery->status = $surgery->is_conflict ? 'conflito' : 'confirmado';
 
         return Inertia::render('Medico/Calendar', [
             'surgery' => $surgery->load(['creator', 'confirmer']),

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -50,10 +50,10 @@ const links = computed(() => props.surgeries.links || []);
 const endTime = (s) => s.end_time || computeEnd(s.start_time, s.expected_duration);
 
 const rowClass = (s) => {
-    if (s.is_conflict || s.status === 'conflict') {
+    if (s.status === 'conflito') {
         return 'bg-red-100 text-red-800 font-bold';
     }
-    if (s.status === 'confirmed') {
+    if (s.status === 'confirmado') {
         return 'bg-green-100 text-green-800';
     }
     return 'bg-blue-100 text-blue-800';


### PR DESCRIPTION
## Summary
- Normalize surgery status values to Portuguese labels across index and confirmation
- Align calendar row styling with new status labels (blue/agendado, green/confirmado, red/conflito)

## Testing
- `npm test` *(fails: command not found)*
- `composer install` *(fails: inertiajs/inertia-laravel requires incompatible PHP version)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c064218198832a90b3d22d9ab71382