### PR TITLE
Reload surgeries after confirmation

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -59,16 +59,12 @@ class SurgeryController extends Controller
     /**
      * Confirm a scheduled surgery.
      */
-    public function confirm(Request $request, Surgery $surgery): Response
+    public function confirm(Request $request, Surgery $surgery): RedirectResponse
     {
         $surgery->confirmed_by = $request->user()->id;
         $surgery->save();
 
-        $surgery->status = 'confirmado';
-
-        return Inertia::render('Medico/Calendar', [
-            'surgery' => $surgery->load(['creator', 'confirmer']),
-        ]);
+        return redirect()->route('surgeries.index');
     }
 }
 

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -41,7 +41,9 @@ const submit = () => {
 };
 
 const confirm = (id) => {
-    router.post(route('surgeries.confirm', id));
+    router.post(route('surgeries.confirm', id), {}, {
+        onSuccess: () => router.reload({ only: ['surgeries'] }),
+    });
 };
 
 const surgeries = computed(() => props.surgeries.data || props.surgeries);


### PR DESCRIPTION
## Summary
- Redirect surgery confirmation to index to provide updated surgeries list
- Refresh surgeries on calendar page after confirmation

## Testing
- `php artisan test` *(fails: Failed opening required '/workspace/calendario/vendor/autoload.php')*
- `composer install` *(fails: inertiajs/inertia-laravel requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.12) does not satisfy that requirement.)*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68c064237f48832ab4cecd29c9939b16