### PR TITLE
Refactor surgeries to use created_by field

### DIFF
--- a/app/Models/Surgery.php
+++ b/app/Models/Surgery.php
@@ -64,17 +64,16 @@ class Surgery extends Model
     {
         static::created(function (Surgery $surgery) {
             $surgery->audits()->create([
-                'doctor_id' => $surgery->doctor_id,
+                'created_by' => $surgery->created_by,
                 'room_number' => $surgery->room,
                 'start_time' => $surgery->starts_at,
                 'end_time' => $surgery->ends_at,
-                'created_by' => auth()->id(),
             ]);
         });
 
         static::updated(function (Surgery $surgery) {
             $surgery->audits()->create([
-                'doctor_id' => $surgery->doctor_id,
+                'created_by' => $surgery->created_by,
                 'room_number' => $surgery->room,
                 'start_time' => $surgery->starts_at,
                 'end_time' => $surgery->ends_at,
@@ -84,7 +83,7 @@ class Surgery extends Model
 
         static::deleted(function (Surgery $surgery) {
             $surgery->audits()->create([
-                'doctor_id' => $surgery->doctor_id,
+                'created_by' => $surgery->created_by,
                 'room_number' => $surgery->room,
                 'start_time' => $surgery->starts_at,
                 'end_time' => $surgery->ends_at,

--- a/app/Models/SurgeryAudit.php
+++ b/app/Models/SurgeryAudit.php
@@ -12,7 +12,6 @@ class SurgeryAudit extends Model
 
     protected $fillable = [
         'surgery_id',
-        'doctor_id',
         'created_by',
         'confirmed_by',
         'room_number',

--- a/database/factories/SurgeryFactory.php
+++ b/database/factories/SurgeryFactory.php
@@ -17,16 +17,13 @@ class SurgeryFactory extends Factory
     public function definition(): array
     {
         $start = Carbon::instance($this->faker->dateTimeBetween('now', '+1 week'));
-        $end = (clone $start)->addHour();
 
         return [
-            'doctor_id' => User::factory(),
-            'room_number' => $this->faker->numberBetween(1, 9),
             'patient_name' => $this->faker->name(),
             'surgery_type' => $this->faker->word(),
-            'expected_duration' => $this->faker->numberBetween(30, 180),
-            'start_time' => $start,
-            'end_time' => $end,
+            'room' => $this->faker->numberBetween(1, 9),
+            'starts_at' => $start,
+            'duration_min' => $this->faker->numberBetween(30, 180),
             'created_by' => User::factory(),
         ];
     }

--- a/database/migrations/2025_09_08_160000_create_surgery_audits_table.php
+++ b/database/migrations/2025_09_08_160000_create_surgery_audits_table.php
@@ -14,8 +14,7 @@ return new class extends Migration
         Schema::create('surgery_audits', function (Blueprint $table) {
             $table->id();
             $table->unsignedBigInteger('surgery_id');
-            $table->unsignedBigInteger('doctor_id');
-            $table->foreignId('created_by')->nullable()->constrained('users');
+            $table->foreignId('created_by')->constrained('users');
             $table->foreignId('confirmed_by')->nullable()->constrained('users');
             $table->integer('room_number');
             $table->timestamp('start_time');

--- a/tests/Feature/SurgeryNotificationTest.php
+++ b/tests/Feature/SurgeryNotificationTest.php
@@ -27,13 +27,11 @@ class SurgeryNotificationTest extends TestCase
         $doctor->assignRole('medico');
 
         $this->actingAs($doctor)->post('/surgeries', [
-            'doctor_id' => $doctor->id,
-            'room_number' => 1,
             'patient_name' => 'John Doe',
             'surgery_type' => 'Appendectomy',
-            'expected_duration' => 60,
-            'start_time' => now()->addHour(),
-            'end_time' => now()->addHours(2),
+            'room' => 1,
+            'duration_min' => 60,
+            'starts_at' => now()->addHour(),
         ]);
 
         Notification::assertSentTo($doctor, UpcomingSurgery::class);


### PR DESCRIPTION
## Summary
- replace `doctor_id` references with `created_by` in surgery and audits
- align factory and tests with new `created_by` relationship
- update migration and audit model to drop obsolete `doctor_id`

## Testing
- `composer install` *(fails: requires GitHub token)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c0642550a8832a92431c58647bbac0