### PR TITLE
Reload surgeries after confirmation

### DIFF
--- a/app/Http/Controllers/SurgeryController.php
+++ b/app/Http/Controllers/SurgeryController.php
@@ -85,16 +85,12 @@ class SurgeryController extends Controller
     /**
      * Confirm a scheduled surgery.
      */
-    public function confirm(Request $request, Surgery $surgery): Response
+    public function confirm(Request $request, Surgery $surgery): RedirectResponse
     {
         $surgery->confirmed_by = $request->user()->id;
         $surgery->save();
 
-        $surgery->status = $surgery->is_conflict ? 'conflito' : 'confirmado';
-
-        return Inertia::render('Medico/Calendar', [
-            'surgery' => $surgery->load(['creator', 'confirmer']),
-        ]);
+        return redirect()->route('surgeries.index');
     }
 }
 

--- a/resources/js/Pages/Medico/Calendar.vue
+++ b/resources/js/Pages/Medico/Calendar.vue
@@ -40,8 +40,14 @@ const submit = () => {
     form.post(route('surgeries.store'));
 };
 
+const fetchSurgeries = () => {
+    router.reload({ only: ['surgeries'] });
+};
+
 const confirm = (id) => {
-    router.post(route('surgeries.confirm', id));
+    router.post(route('surgeries.confirm', id), {}, {
+        onSuccess: () => fetchSurgeries(),
+    });
 };
 
 const surgeries = computed(() => props.surgeries.data || props.surgeries);


### PR DESCRIPTION
## Summary
- Redirect confirmed surgeries back to surgeries list
- Refresh surgeries list on confirmation in calendar view

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.12) does not satisfy that requirement.)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68c06c8209a8832abbe68f1c296fa2ec