### PR TITLE
Configure Vite dev server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -18,4 +18,9 @@ export default defineConfig({
             },
         }),
     ],
+    server: {
+        host: 'localhost',
+        port: 5173,
+        hmr: { host: 'localhost', protocol: 'ws', port: 5173 },
+    },
 });


### PR DESCRIPTION
## Summary
- specify host/port options for Vite dev server and HMR

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68c07b38c9d0832a8cdad9f62e8a1f3f