### PR TITLE
Group surgery routes under auth middleware

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -33,8 +33,11 @@ Route::middleware(['auth', 'role:adm|medico|enfermeiro'])->group(function () {
 });
 
 Route::middleware(['auth', 'role:adm'])->get('/admin', fn () => 'admin area');
-Route::middleware(['auth', 'role:medico|enfermeiro'])->get('/surgeries', [SurgeryController::class, 'index'])->name('surgeries.index');
-Route::middleware(['auth', 'role:medico'])->post('/surgeries', [SurgeryController::class, 'store'])->name('surgeries.store');
-Route::middleware(['auth', 'role:enfermeiro'])->post('/surgeries/{surgery}/confirm', [SurgeryController::class, 'confirm'])->name('surgeries.confirm');
+
+Route::middleware(['auth'])->group(function () {
+    Route::get('/surgeries', [SurgeryController::class, 'index'])->name('surgeries.index');
+    Route::post('/surgeries', [SurgeryController::class, 'store'])->middleware('role:medico')->name('surgeries.store');
+    Route::post('/surgeries/{surgery}/confirm', [SurgeryController::class, 'confirm'])->middleware('role:enfermeiro')->name('surgeries.confirm');
+});
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
## Summary
- group surgery routes under auth middleware
- add role-specific middleware for storing and confirming surgeries

## Testing
- `composer install`
- `php artisan test` *(fails: Failed opening required '/workspace/calendario/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_68c1863aafac832a87beb13c249b0ffc