### PR TITLE
Stop exposing user roles

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,7 +3,6 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
-use Inertia\Inertia;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -20,17 +19,12 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Inertia::share([
-            'auth' => function () {
-                $u = auth()->user();
-                return $u ? [
-                    'user' => [
-                        'id' => $u->id,
-                        'name' => $u->name,
-                        'roles' => $u->getRoleNames(),
-                    ],
-                ] : null;
-            },
+        \Inertia\Inertia::share([
+            'auth' => fn () => [
+                'user' => auth()->user()
+                    ? ['id' => auth()->id(), 'name' => auth()->user()->name]
+                    : null,
+            ],
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- Simplify Inertia shared auth data to include only user id and name

## Testing
- `composer install` *(fails: inertiajs/inertia-laravel v0.6.11 requires php ^7.2|~8.0.0|~8.1.0|~8.2.0|~8.3.0 -> your php version (8.4.12) does not satisfy that requirement.)*

------
https://chatgpt.com/codex/tasks/task_e_68c1863da184832aab890758474dbff3